### PR TITLE
Fix temp allow expiration

### DIFF
--- a/block-page.js
+++ b/block-page.js
@@ -65,8 +65,8 @@ function allowTemporaryAccess() {
     return;
   }
 
-  // 임시 허용 시간 설정 (5분)
-  const allowInfo = { remaining: 5 * 60 * 1000 };
+  // 임시 허용 시간 설정 (만료 시각 기록)
+  const allowInfo = Date.now() + 5 * 60 * 1000; // 5분 후 만료
 
   // 로컬 스토리지에 임시 허용 정보 저장
   const tempAllowKey = `temp_allow_${domain}`;

--- a/siteTracker.js
+++ b/siteTracker.js
@@ -272,7 +272,7 @@ export class SiteTracker {
     remaining -= duration;
 
     if (remaining > 0) {
-      await chrome.storage.local.set({ [key]: { remaining } });
+      await chrome.storage.local.set({ [key]: Date.now() + remaining });
     } else {
       await chrome.storage.local.remove([key]);
     }


### PR DESCRIPTION
## Summary
- store expiration timestamp when temporarily allowing access
- persist updated timestamp when deducting time

## Testing
- `node -c block-page.js`
- `node -c siteTracker.js`


------
https://chatgpt.com/codex/tasks/task_e_6851ac10a9208330b83938da83a36e6f